### PR TITLE
fixed bugs in table.scan with 'limit' and row keys that cannot be UTF-8 encoded

### DIFF
--- a/happybase_mock/table.py
+++ b/happybase_mock/table.py
@@ -135,6 +135,10 @@ class Table(object):
              batch_size=1000, scan_batching=None, limit=None,
              reverse=False, sorted_columns=False, **kwargs):
         # encode columns key and data (for python3 compatibility)
+        if reverse:
+            old_row_start = row_start
+            row_start = row_stop
+            row_stop = old_row_start
         if columns:
           for i, col in enumerate(columns):
             if not isinstance(col, bytes):
@@ -161,11 +165,17 @@ class Table(object):
         else:
             rows = self._data.keys()
 
-        rows = filter(lambda k: k >= row_start, rows)
+        if not reverse:
+            rows = filter(lambda k: k >= row_start, rows)
+        else:
+            rows = filter(lambda k: k > row_start, rows)
         if row_stop is not None:
             if not isinstance(row_stop, bytes):
                 row_stop = row_stop.encode('utf-8')
-            rows = filter(lambda k: k < row_stop, rows)
+            if not reverse:
+                rows = filter(lambda k: k < row_stop, rows)
+            else:
+                rows = filter(lambda k: k <= row_stop, rows)
 
         result = sorted([
             (row, self.row(row, columns, timestamp, include_timestamp))

--- a/happybase_mock/table.py
+++ b/happybase_mock/table.py
@@ -246,6 +246,8 @@ class Table(object):
             if not columns:
                 # Delete all columns if not specified
                 columns = data.keys()
+            else:
+                columns = list(set(columns) & data.keys())
 
             if timestamp is None:
                 timestamp = int(time.time() * 1000)

--- a/happybase_mock/table.py
+++ b/happybase_mock/table.py
@@ -156,7 +156,12 @@ class Table(object):
             if not isinstance(row_start, bytes):
                 row_start = row_start.encode('utf-8')
 
-        rows = filter(lambda k: k >= row_start, self._data)
+        if columns:
+            rows = (k for k, v in self._data.items() if set(columns).intersection(v))
+        else:
+            rows = self._data.keys()
+
+        rows = filter(lambda k: k >= row_start, rows)
         if row_stop is not None:
             if not isinstance(row_stop, bytes):
                 row_stop = row_stop.encode('utf-8')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -262,6 +262,22 @@ class TestTable(BaseTestCase):
             (b'2', {b'd:count': b'2'})
         ])
 
+    def test_scan_with_multiple_columns(self):
+        self.table.put(b'1', {b'd:first': 'f1'})
+
+        self.table.put(b'2', {b'd:first': 'f2',
+                              b'd:second': 's2'})
+
+        self.table.put(b'3', {b'd:first': 'f3',
+                              b'd:second': 's3',
+                              b'd:third': 't3'})
+
+        self.assertEqual(list(self.table.scan(columns=[b'd:first', b'd:second'])), [
+            (b'1', {b'd:first': b'f1'}),
+            (b'2', {b'd:first': b'f2', b'd:second': b's2'}),
+            (b'3', {b'd:first': b'f3', b'd:second': b's3'})
+        ])
+
     def test_scan_arbitrary_binary_row_keys(self):
         common_prefix = md5(b'common_prefix').digest()
         row_key1 = b''.join([common_prefix, b'key1'])

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -290,6 +290,30 @@ class TestTable(BaseTestCase):
             (row_key2, {b'd:value': b'value2'})
         ])
 
+    def test_scan_with_row_start_and_row_stop_and_reverse(self):
+        self.table.put(b'1', {b'd:value': b'value1'})
+        self.table.put(b'2', {b'd:value': b'value2'})
+        self.table.put(b'3', {b'd:value': b'value3'})
+        self.table.put(b'4', {b'd:value': b'value4'})
+        self.table.put(b'5', {b'd:value': b'value5'})
+
+        self.assertEqual(list(self.table.scan(row_start=b"4", row_stop=b"2", reverse=True)),[
+            (b'4', {b'd:value': b'value4'}),
+            (b'3', {b'd:value': b'value3'})
+        ])
+
+        self.assertEqual(list(self.table.scan(row_start=b"3", reverse=True)),[
+            (b'3', {b'd:value': b'value3'}),
+            (b'2', {b'd:value': b'value2'}),
+            (b'1', {b'd:value': b'value1'})
+        ])
+
+        self.assertEqual(list(self.table.scan(row_stop=b"3", reverse=True)),[
+            (b'5', {b'd:value': b'value5'}),
+            (b'4', {b'd:value': b'value4'})
+        ])
+
+
     def test_scan_invalid_arguments(self):
         with self.assertRaises(TypeError):
             self.table.scan(row_start=b'1', row_stop=b'2', row_prefix=b'3')


### PR DESCRIPTION
Hi, could you please consider merging this into master:
 - limit flag in `table.scan` now works correctly (bug with sign fixed)
 - `row_prefix` flag now can be arbitrary binary string which is the case for MD5 generated row keys. These keys cannot be UTF-8 encoded which made testing such database usage impossible. To fix this latest functionality from happybase was taken.